### PR TITLE
Remove the use of Array Destructuring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ module.exports = function(text, length, options) {
   }
   invert = typeof text === 'number';
   if (invert) {
-    [length, text] = [text, length];
+    length = [text, text=length][0];
   }
   if (typeof options === 'string') {
     options = {


### PR DESCRIPTION
By changing this line we guarantee the compatibility of less node versions ( **>= 4.0.0** ). Because **Array Destructuring** is not supported until **Node 6.0.0** since it is an ES6 feature.